### PR TITLE
Add a CODEOWNERS file to specify the reviewers who can approve PR merges

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @foxtron-ev/foxtronpi-pyclient


### PR DESCRIPTION
Only PRs approved by members of the foxtronpi-pyclient group can be merged.
The following are the members of the `foxtronpi-pyclient` group:
1. YC
2. Boris
3. Sirius
4. Mark
5. Wayne
